### PR TITLE
Improve style

### DIFF
--- a/css/idcard.css
+++ b/css/idcard.css
@@ -396,7 +396,7 @@
 }
 
 #biliscope-id-card .biliscope-badge-video-tag {
-    background-color: #00a1d6;
+    background-color: #00aeec;
 }
 
 #biliscope-id-card .biliscope-badge-note-tag {

--- a/css/idcard.css
+++ b/css/idcard.css
@@ -386,8 +386,9 @@
 #biliscope-id-card .biliscope-badge {
     color: white;
     display: inline-block;
-    padding: 0px 10px;
-    line-height: 24px;
+    padding: 5px 7px;
+    margin: 2px;
+    line-height: 12px;
     vertical-align: top;
     font-size: 12px;
     font-weight: 600;


### PR DESCRIPTION
这个 PR 做出了如下改动：

1. 个人资料页的备注区在 hover 状态时使用B站品牌色作为边框颜色
2. 悬浮卡片上 UP 主标签的背景颜色使用B站品牌色，之前的颜色比较深暗，在整个页面中的观感稍差
3. 调整了标签的 padding 和 margin 距离，占用面积更小，多行标签时行与行之间有适当的间隔

| 调整前 | 调整后 |
| --- | --- |
| ![image](https://github.com/gaogaotiantian/biliscope/assets/41742767/d9b0be41-89c5-4e48-8a87-ba041f051b9a) | ![image](https://github.com/gaogaotiantian/biliscope/assets/41742767/0996c0ee-73e4-4386-857f-2f9193366f0e) |
