### PR TITLE
fix deregistration display bug

### DIFF
--- a/scripts/biliscope.js
+++ b/scripts/biliscope.js
@@ -21,16 +21,23 @@ function getTarget(target) {
     return null;
 }
 
-function showProfile(event) {
+async function showProfile(event) {
     let target = getTarget(event.target);
 
-    if (target && userProfileCard && userProfileCard.enable()) {
+    if (target && userProfileCard) {
         let userId = target.getAttribute("biliscope-userid");
-        let updated = userProfileCard.updateUserId(userId);
-        userProfileCard.updateCursor(event.pageX, event.pageY);
-        userProfileCard.updateTarget(target)
-        if (updated) {
-            updateUserInfo(userId, (data) => userProfileCard.updateData(data));
+
+        if (await isDeregistration(userId)) {
+            return
+        }
+
+        if (userProfileCard.enable()) {
+            let updated = userProfileCard.updateUserId(userId);
+            userProfileCard.updateCursor(event.pageX, event.pageY);
+            userProfileCard.updateTarget(target)
+            if (updated) {
+                updateUserInfo(userId, (data) => userProfileCard.updateData(data));
+            }
         }
     }
 }


### PR DESCRIPTION
#81 
这个处理方案是对于已注销的账号不显示插件的弹窗。（如果你有其他的想法的话我可以修改）

在showProfile的时候判断用户是不是已注销，注销不显示弹窗。

在isDeregistration中判断是否命中缓存中的info，如果未命中则请求info接口，根据code返回该用户是否已注销。

cacheAndUpdate这个方法我把存储的部分单独提出来了供isDeregistration方法使用（不提出来也可以传入一个空的callback来完成）