### PR TITLE
fix if guardInfo length is 0 user information cannot be display bug

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -146,7 +146,7 @@ function getUserProfileCardDataHTML(data) {
 }
 
 function getGuardSupportHTML(data) {
-    if (guardInfo == null) {
+    if (guardInfo == null || guardInfo.length === 0) {
         return "";
     }
 


### PR DESCRIPTION
如果没有舰长的话，会出现这样的情况
![image](https://github.com/gaogaotiantian/biliscope/assets/34330320/f26f28a8-68f9-4b23-8c5a-38854348f923)
