### PR TITLE
Fix the issue of not accessing the last page of data

### DIFF
--- a/scripts/biliapi.js
+++ b/scripts/biliapi.js
@@ -173,8 +173,12 @@ function updateVideoData(userId, callback) {
             let count = data["data"]["page"]["count"];
             cacheAndUpdate(callback, userId, "count", {"count": count});
 
-            let lastVideoTimestamp = count > 0 ? data["data"]["list"]["vlist"][0]["created"] : null;
-            cacheAndUpdate(callback, userId, "lastVideoTimestamp", {"timestamp": lastVideoTimestamp});
+            if (count > 0) {
+                let lastVideoTimestamp = data["data"]["list"]["vlist"][0]["created"];
+                cacheAndUpdate(callback, userId, "lastVideoTimestamp", { "timestamp": lastVideoTimestamp });
+            } else {
+                cacheAndUpdate(callback, userId, "lastVideoTimestamp", { "timestamp": null });
+            }
 
             let pn = 1;
             let promises = [];
@@ -280,20 +284,20 @@ async function requestGuardPage(roomid, uid, pn, map) {
 async function getGuardInfo(roomId, uid) {
     let map = new Map();
     return requestGuardPage(roomId, uid, 1, map).then((data) => {
-        if (data["code"] == 0) {
-            let count = data["data"]["info"]["num"];
-            let pn = 1;
-            let promises = [];
-            while (pn * 30 < count) {
-                pn += 1;
-                promises.push(requestGuardPage(roomId, uid, pn, map));
-            }
-            return Promise.all(promises).then((values) => {
-                return Array.from(map.values());
-            })
-        } else {
+        if (data["code"] != 0) {
             return [];
         }
+        let count = data["data"]["info"]["num"];
+        let pn = 1;
+        let promises = [];
+        while (pn * 30 < count) {
+            pn += 1;
+            promises.push(requestGuardPage(roomId, uid, pn, map));
+        }
+        return Promise.all(promises).then((values) => {
+            let data = Array.from(map.values());
+            return data
+        })
     });
 }
 

--- a/scripts/biliapi.js
+++ b/scripts/biliapi.js
@@ -175,9 +175,9 @@ function updateVideoData(userId, callback) {
 
             if (count > 0) {
                 let lastVideoTimestamp = data["data"]["list"]["vlist"][0]["created"];
-                cacheAndUpdate(callback, userId, "lastVideoTimestamp", { "timestamp": lastVideoTimestamp });
+                cacheAndUpdate(callback, userId, "lastVideoTimestamp", {"timestamp": lastVideoTimestamp});
             } else {
-                cacheAndUpdate(callback, userId, "lastVideoTimestamp", { "timestamp": null });
+                cacheAndUpdate(callback, userId, "lastVideoTimestamp", {"timestamp": null});
             }
 
             let pn = 1;

--- a/scripts/biliapi.js
+++ b/scripts/biliapi.js
@@ -163,12 +163,13 @@ async function requestSearchPage(userId, pn, map) {
 
 function updateVideoData(userId, callback) {
     let map = new Map();
+    let pn = 1;
     map.set("word", new Map());
     map.set("type", new Map());
     map.set("lastMonthVideoCount", 0);
     map.set("totalVideoLength", 0);
 
-    requestSearchPage(userId, 1, map).then((data) => {
+    requestSearchPage(userId, pn, map).then((data) => {
         if (data["code"] == 0) {
             let count = data["data"]["page"]["count"];
             cacheAndUpdate(callback, userId, "count", {"count": count});
@@ -182,10 +183,9 @@ function updateVideoData(userId, callback) {
 
             let promises = [];
             if (count > NUM_PER_PAGE) {
-                let pn = 2;
                 while (pn * NUM_PER_PAGE < count) {
-                    promises.push(requestSearchPage(userId, pn, map));
                     pn += 1;
+                    promises.push(requestSearchPage(userId, pn, map));
                 }
                 Promise.all(promises).then((values) => {
                     cacheAndUpdate(callback, userId, "wordcloud", convertVideoData(map));
@@ -296,10 +296,9 @@ async function getGuardInfo(roomId, uid) {
         if (data["code"] == 0) {
             let count = data["data"]["info"]["num"];
             if (count > 30) {
-                let pn = 2;
                 while (pn * 30 < count) {
-                    promises.push(requestGuardPage(roomId, uid, pn, map));
                     pn += 1;
+                    promises.push(requestGuardPage(roomId, uid, pn, map));
                 }
                 return Promise.all(promises).then((values) => {
                     let data = Array.from(map.values());


### PR DESCRIPTION
### 两个 request 问题

- 访问 SearchPage 时，没有请求最后一页数据，导致无法获取完整的投稿列表

- 类似地，访问 GuardInfo 时，也没有请求最后一页数据，导致无法获取完整的舰长列表

### 具体更改

- 统一先声明变量 `let pn = 1`
- 在循环中，若是需要访问下一页数据，`pn += 1`

### 图一是修改前的情况
![Snipaste_2024-01-03_19-58-00](https://github.com/gaogaotiantian/biliscope/assets/43172664/84694397-840d-4619-9908-90d2763df594)


### 图二是修改后的情况
![Snipaste_2024-01-03_20-01-41](https://github.com/gaogaotiantian/biliscope/assets/43172664/2306649a-b26b-4290-bfd0-d9a4791ec1b7)


