### PR TITLE
Fix unexpected condition in `updateData`

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -642,10 +642,11 @@ UserProfileCard.prototype.updateData = function (data) {
             canvas.style.height = "0px";
             canvas.height = 0;
         }
-    } else if (data["data"]["name"]) {
-        document.getElementById("biliscope-id-card-data").innerHTML = getUserProfileCardDataHTML(this.data);
+    } else if (data["data"]?.["name"]) {
         this.setupTriggers();
         this.drawVideoTags();
+    } else if (this.data["name"]) {
+        document.getElementById("biliscope-id-card-data").innerHTML = getUserProfileCardDataHTML(this.data);
     }
 
     if (this.enabled && this.valid && this.el?.style.display != "flex") {

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -643,14 +643,12 @@ UserProfileCard.prototype.updateData = function (data) {
             canvas.style.height = "0px";
             canvas.height = 0;
         }
-    } else if (this.data['name']) {
-        // wait until name is ready
+    } else if (data["data"]["name"]) {
         document.getElementById("biliscope-id-card-data").innerHTML = getUserProfileCardDataHTML(this.data);
         this.setupTriggers();
-        this.drawVideoTags();
     }
 
-    if (this.enabled && this.valid && this.el && this.el.style.display != "flex") {
+    if (this.enabled && this.valid && this.el?.style.display != "flex") {
         this.clearOriginalCard();
         this.el.style.display = "flex";
     }

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -638,7 +638,6 @@ UserProfileCard.prototype.updateData = function (data) {
         let canvas = document.getElementById("word-cloud-canvas");
         if (this.data["wordcloud"].length > 0) {
             this.drawWordCloud(canvas);
-            this.drawVideoTags();
         } else {
             canvas.style.height = "0px";
             canvas.height = 0;
@@ -646,6 +645,7 @@ UserProfileCard.prototype.updateData = function (data) {
     } else if (data["data"]["name"]) {
         document.getElementById("biliscope-id-card-data").innerHTML = getUserProfileCardDataHTML(this.data);
         this.setupTriggers();
+        this.drawVideoTags();
     }
 
     if (this.enabled && this.valid && this.el?.style.display != "flex") {

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -646,6 +646,7 @@ UserProfileCard.prototype.updateData = function (data) {
         this.setupTriggers();
         this.drawVideoTags();
     } else if (this.data["name"]) {
+        // wait until name is ready
         document.getElementById("biliscope-id-card-data").innerHTML = getUserProfileCardDataHTML(this.data);
     }
 


### PR DESCRIPTION
完成的事情
> 只有 `data["api"] == "info"` 时才会有 `data["data"]["name"]` ，既然视频信息(包括视频对应的 up 名)都获取不到(基本不会出现，出现了大概率也是 b 站崩了)，那就没必要给 up 设置备注和获取视频分区了。
- 使两个函数只调用一次
- 删除重复调用的 `this.drawVideoTags()`
- 使用 `?.` 减少 `&&` 判断