### PR TITLE
Fix unable to refresh recommended video on the homepage

### DIFF
--- a/scripts/rollbackfeedcard.js
+++ b/scripts/rollbackfeedcard.js
@@ -76,6 +76,7 @@ FeedcardManager.prototype.onRollFeedcard = function () {
     const observer = new MutationObserver((mutationsList, observer) => {
         for (const mutation of mutationsList) {
             if (mutation.type === 'childList') {
+                this.adFeedcards.clear();
                 document.querySelectorAll('.feed-card').forEach(feedcard => {
                     if (isAdFeedcard(feedcard)) {
                         this.adFeedcards.add(feedcard);


### PR DESCRIPTION
### Bug原因

我们在换一换之后会将原来的feedcard移出DOM，而如果新刷出来的feedcard中有跟上次一样的广告card，vue会复用这个节点，但是这个节点已经被我们移除了，所以在下次换一换的时候会出问题。

### 解决方案

由于没有想到优雅的方案获得每次刷新需要的广告card，所以决定把所有出现过的广告节点都存在Set里，同时栈中只存非广告节点，每次操作（换一换、前进、后退）后把所有广告节点追加到最后（后面的card其实不显示，而且广告变来变去也就几种，性能影响不大），这样就保证DOM中一定有要复用的节点。

fix #211 