### PR TITLE
Fix blurry on retina screens

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -669,6 +669,7 @@ UserProfileCard.prototype.drawWordCloud = function(canvas) {
         weightFactor: 100 / this.wordCloudMaxCount() * window.devicePixelRatio,
         shrinkToFit: true,
         minSize: biliScopeOptions.minSize
+        minSize: biliScopeOptions.minSize * window.devicePixelRatio
     });
 }
 

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -658,15 +658,15 @@ UserProfileCard.prototype.setupTriggers = function() {
 
 UserProfileCard.prototype.drawWordCloud = function(canvas) {
     canvas.style.height = `${canvas.offsetWidth / 2}px`;
-    canvas.width = canvas.offsetWidth;
-    canvas.height = canvas.offsetHeight;
+    canvas.width = canvas.offsetWidth * window.devicePixelRatio;
+    canvas.height = canvas.offsetHeight * window.devicePixelRatio;
 
     canvas.parentNode.classList.add("biliscope-canvas-show");
 
     WordCloud(canvas, {
         list: JSON.parse(JSON.stringify(this.data["wordcloud"])),
         backgroundColor: "transparent",
-        weightFactor: 100 / this.wordCloudMaxCount(),
+        weightFactor: 100 / this.wordCloudMaxCount() * window.devicePixelRatio,
         shrinkToFit: true,
         minSize: biliScopeOptions.minSize
     });


### PR DESCRIPTION
close: #221 

- [Window: devicePixelRatio property - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio#:~:text=A%20%3Ccanvas%3E%20can%20appear%20too%20blurry%20on%20retina%20screens.%20Use%20window.devicePixelRatio%20to%20determine%20how%20much%20extra%20pixel%20density%20should%20be%20added%20to%20allow%20for%20a%20sharper%20image.)
- [Blurred output · Issue #81 · timdream/wordcloud2.js](https://github.com/timdream/wordcloud2.js/issues/81)