### PR TITLE
Fix accidentally closed the original popover

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -459,23 +459,19 @@ UserProfileCard.prototype.setLeaveEvent = function() {
     // the leave event. We need to dispatch the event to the popover to prevent
     // the popover from disappearing.
     const dispatchToPopover = (event) => {
-        let node = this.target;
-        while (node && node != document) {
-            if (node.classList && node.classList.contains("v-popover")) {
-                node.dispatchEvent(new Event(event));
-                break;
-            }
-            node = node.parentNode;
-        }
+        const popover = this.target.closest(".v-popover");
+        popover?.dispatchEvent(new Event(event));
     }
 
-    this.leaveCallback = () => {
+    this.leaveCallback = (ev) => {
         if (this.disable()) {
             for (let target of validTargets) {
                 target.removeEventListener("mouseleave", this.disableDebounce);
                 target.removeEventListener("mouseenter", this.enterCallback);
             }
-            dispatchToPopover("mouseleave");
+            if (ev.target == this.el) {
+                dispatchToPopover("mouseleave");
+            }
         }
     }
 
@@ -485,10 +481,10 @@ UserProfileCard.prototype.setLeaveEvent = function() {
         this.cursorInside = true;
     }
 
-    this.disableDebounce = () => {
+    this.disableDebounce = (ev) => {
         this.cursorInside = false;
         this.disableDebounce.timer = setTimeout(() => {
-            this.leaveCallback();
+            this.leaveCallback(ev);
         }, 400);
     }
 

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -475,9 +475,11 @@ UserProfileCard.prototype.setLeaveEvent = function() {
         }
     }
 
-    this.enterCallback = () => {
+    this.enterCallback = (ev) => {
         clearTimeout(this.disableDebounce.timer);
-        dispatchToPopover("mouseenter");
+        if (ev.target == this.el) {
+            dispatchToPopover("mouseenter");
+        }
         this.cursorInside = true;
     }
 

--- a/scripts/videoui.js
+++ b/scripts/videoui.js
@@ -199,9 +199,11 @@ VideoProfileCard.prototype.setLeaveEvent = function() {
         }
     }
 
-    this.enterCallback = () => {
+    this.enterCallback = (ev) => {
         clearTimeout(this.disableDebounce.timer);
-        dispatchToPopover("mouseenter");
+        if (ev.target == this.el) {
+            dispatchToPopover("mouseenter");
+        }
     }
 
     this.disableDebounce = (ev) => {

--- a/scripts/videoui.js
+++ b/scripts/videoui.js
@@ -183,23 +183,19 @@ VideoProfileCard.prototype.setLeaveEvent = function() {
     // the leave event. We need to dispatch the event to the popover to prevent
     // the popover from disappearing.
     const dispatchToPopover = (event) => {
-        let node = this.target;
-        while (node && node != document) {
-            if (node.classList && node.classList.contains("v-popover")) {
-                node.dispatchEvent(new Event(event));
-                break;
-            }
-            node = node.parentNode;
-        }
+        const popover = this.target.closest(".v-popover");
+        popover?.dispatchEvent(new Event(event));
     }
 
-    this.leaveCallback = () => {
+    this.leaveCallback = (ev) => {
         if (this.disable()) {
             for (let target of validTargets) {
                 target.removeEventListener("mouseleave", this.disableDebounce);
                 target.removeEventListener("mouseenter", this.enterCallback);
             }
-            dispatchToPopover("mouseleave");
+            if (ev.target == this.el) {
+                dispatchToPopover("mouseleave");
+            }
         }
     }
 
@@ -208,9 +204,9 @@ VideoProfileCard.prototype.setLeaveEvent = function() {
         dispatchToPopover("mouseenter");
     }
 
-    this.disableDebounce = () => {
+    this.disableDebounce = (ev) => {
         this.disableDebounce.timer = setTimeout(() => {
-            this.leaveCallback();
+            this.leaveCallback(ev);
         }, 400);
     }
 


### PR DESCRIPTION
`this.el` 是 biliscope 的视频卡片，而 `this.target` 是b站弹窗的一部分，它不应该派遣b站弹窗的 `mouseleave` 事件，来防止派遣b站弹窗 `mouseenter` 事件不生效时出现的意外关闭。

---

fix #239 