### PR TITLE
Make sure the original card is cleared

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -347,20 +347,10 @@ UserProfileCard.prototype.clearOriginalCard = function() {
         document.getElementById("id-card").remove();
     }
 
-    for (let card of document.getElementsByClassName("user-card")) {
+    for (const card of document.querySelectorAll(".user-card, .card-loaded, .bili-user-profile, bili-user-profile")) {
         card.hidden = true;
-    }
-
-    for (let card of document.getElementsByClassName("card-loaded")) {
-        card.hidden = true;
-    }
-
-    for (let card of document.getElementsByClassName("bili-user-profile")) {
-        card.hidden = true;
-    }
-
-    for (let card of document.getElementsByTagName("bili-user-profile")) {
         card.style.display = "none";
+        card.style.visibility = "hidden";
     }
 }
 


### PR DESCRIPTION
`card.style.display = "none";`会出现一个racing condition，因为B站自己的代码是改`display`的，有可能biliscope先设置成`none`，然后B站把`display`又调回去了，就会导致两个card都存在，很容易复现。

这里尽可能把card给藏起来，visibility是B站现在没用的方式，hidden在某些页面（视频下）是工作的，所以全用上。