### PR TITLE
Add `this.valid = false` to VideoProfileCard

### DIFF
--- a/scripts/videoui.js
+++ b/scripts/videoui.js
@@ -131,7 +131,7 @@ function VideoProfileCard() {
     this.enabled = false;
     this.data = {};
     this.target = null;
-    this.enabled = false;
+    this.valid = false;
     this.videoId = null;
     this.el = document.createElement("div");
     this.el.style.position = "absolute";


### PR DESCRIPTION
视频卡片这边有两个 `this.enabled = false;`，却没有 `this.valid` 的显式初始化，把一个改掉了。
没出 bug 的原因是下面调用了 `this.disable();`，算是隐式初始化了，但还是得显式初始化 `this.valid`。