### PR TITLE
Display user card for at-user in comment

### DIFF
--- a/scripts/load.js
+++ b/scripts/load.js
@@ -76,8 +76,6 @@ window.addEventListener("load", function() {
             for (const comment of comments) {
                 const feed = comment?.shadowRoot?.children?.contents?.children?.feed;
 
-                tryObserve(comment?.shadowRoot);
-
                 if (!feed) {
                     return;
                 }
@@ -86,10 +84,7 @@ window.addEventListener("load", function() {
                     const mainComment = commentStack.shadowRoot.children.comment;
                     const replies = commentStack.shadowRoot.children?.replies;
 
-                    tryObserve(commentStack.shadowRoot);
-
                     if (mainComment) {
-                        tryObserve(mainComment.shadowRoot);
                         const avatar = mainComment.shadowRoot.getElementById("user-avatar");
                         avatar?.addEventListener("mouseover", showProfileDebounce);
 
@@ -108,30 +103,29 @@ window.addEventListener("load", function() {
                     }
 
                     if (replies) {
-                        tryObserve(replies.children[0].shadowRoot);
-                        for (const reply of replies.children[0].shadowRoot
-                                            .querySelectorAll("bili-comment-reply-renderer")) {
-                            tryObserve(reply.shadowRoot);
-                            const userInfo = reply.shadowRoot.querySelector("bili-comment-user-info");
-                            if (userInfo) {
-                                const avatar = userInfo.querySelector("#user-avatar");
-                                avatar?.addEventListener("mouseover", showProfileDebounce);
+                        const repliesInner = replies.children[0].shadowRoot;
+                        tryObserve(repliesInner.getElementById("expander-footer"));
 
-                                tryObserve(userInfo.shadowRoot);
-                                const userNameA = userInfo.shadowRoot?.querySelector("#user-name > a");
-                                userNameA?.addEventListener("mouseover", showProfileDebounce);
-                            }
+                        setTimeout(() => {
+                            for (const reply of repliesInner.querySelectorAll("bili-comment-reply-renderer")) {
+                                const userInfo = reply.shadowRoot.querySelector("bili-comment-user-info");
+                                if (userInfo) {
+                                    const avatar = userInfo.querySelector("#user-avatar");
+                                    avatar?.addEventListener("mouseover", showProfileDebounce);
 
-                            const richText = reply.shadowRoot.querySelector("bili-rich-text");
-                            if (richText) {
-                                setTimeout(() => {
+                                    const userNameA = userInfo.shadowRoot?.querySelector("#user-name > a");
+                                    userNameA?.addEventListener("mouseover", showProfileDebounce);
+                                }
+
+                                const richText = reply.shadowRoot.querySelector("bili-rich-text");
+                                if (richText) {
                                     const userNameAts = richText.shadowRoot.querySelectorAll("a[data-user-profile-id]");
                                     for (const userNameAt of userNameAts) {
                                         userNameAt.addEventListener("mouseover", showProfileDebounce);
                                     }
-                                }, 0);
+                                }
                             }
-                        }
+                        }, 0);
                     }
 
                 }

--- a/scripts/load.js
+++ b/scripts/load.js
@@ -100,7 +100,7 @@ window.addEventListener("load", function() {
 
                         const richText = mainComment.shadowRoot.querySelector("bili-rich-text");
                         if (richText) {
-                            const userNameAts = richText.shadowRoot.querySelectorAll("a");
+                            const userNameAts = richText.shadowRoot.querySelectorAll("a[data-user-profile-id]");
                             for (const userNameAt of userNameAts) {
                                 userNameAt.addEventListener("mouseover", showProfileDebounce);
                             }
@@ -124,7 +124,7 @@ window.addEventListener("load", function() {
 
                             const richText = reply.shadowRoot.querySelector("bili-rich-text");
                             if (richText) {
-                                const userNameAts = richText.shadowRoot.querySelectorAll("a");
+                                const userNameAts = richText.shadowRoot.querySelectorAll("a[data-user-profile-id]");
                                 for (const userNameAt of userNameAts) {
                                     userNameAt.addEventListener("mouseover", showProfileDebounce);
                                 }

--- a/scripts/load.js
+++ b/scripts/load.js
@@ -97,6 +97,14 @@ window.addEventListener("load", function() {
                                           ?.querySelector("bili-comment-user-info")?.shadowRoot
                                           ?.querySelector("#user-name > a");
                         userNameA?.addEventListener("mouseover", showProfileDebounce);
+
+                        const richText = mainComment.shadowRoot.querySelector("bili-rich-text");
+                        if (richText) {
+                            const userNameAts = richText.shadowRoot.querySelectorAll("a");
+                            for (const userNameAt of userNameAts) {
+                                userNameAt.addEventListener("mouseover", showProfileDebounce);
+                            }
+                        }
                     }
 
                     if (replies) {
@@ -112,6 +120,14 @@ window.addEventListener("load", function() {
                                 tryObserve(userInfo.shadowRoot);
                                 const userNameA = userInfo.shadowRoot?.querySelector("#user-name > a");
                                 userNameA?.addEventListener("mouseover", showProfileDebounce);
+                            }
+
+                            const richText = reply.shadowRoot.querySelector("bili-rich-text");
+                            if (richText) {
+                                const userNameAts = richText.shadowRoot.querySelectorAll("a");
+                                for (const userNameAt of userNameAts) {
+                                    userNameAt.addEventListener("mouseover", showProfileDebounce);
+                                }
                             }
                         }
                     }

--- a/scripts/load.js
+++ b/scripts/load.js
@@ -76,6 +76,8 @@ window.addEventListener("load", function() {
             for (const comment of comments) {
                 const feed = comment?.shadowRoot?.children?.contents?.children?.feed;
 
+                tryObserve(comment?.shadowRoot);
+
                 if (!feed) {
                     return;
                 }
@@ -84,7 +86,10 @@ window.addEventListener("load", function() {
                     const mainComment = commentStack.shadowRoot.children.comment;
                     const replies = commentStack.shadowRoot.children?.replies;
 
+                    tryObserve(commentStack.shadowRoot);
+
                     if (mainComment) {
+                        tryObserve(mainComment.shadowRoot);
                         const avatar = mainComment.shadowRoot.getElementById("user-avatar");
                         avatar?.addEventListener("mouseover", showProfileDebounce);
 
@@ -103,29 +108,30 @@ window.addEventListener("load", function() {
                     }
 
                     if (replies) {
-                        const repliesInner = replies.children[0].shadowRoot;
-                        tryObserve(repliesInner.getElementById("expander-footer"));
+                        tryObserve(replies.children[0].shadowRoot);
+                        for (const reply of replies.children[0].shadowRoot
+                                            .querySelectorAll("bili-comment-reply-renderer")) {
+                            tryObserve(reply.shadowRoot);
+                            const userInfo = reply.shadowRoot.querySelector("bili-comment-user-info");
+                            if (userInfo) {
+                                const avatar = userInfo.querySelector("#user-avatar");
+                                avatar?.addEventListener("mouseover", showProfileDebounce);
 
-                        setTimeout(() => {
-                            for (const reply of repliesInner.querySelectorAll("bili-comment-reply-renderer")) {
-                                const userInfo = reply.shadowRoot.querySelector("bili-comment-user-info");
-                                if (userInfo) {
-                                    const avatar = userInfo.querySelector("#user-avatar");
-                                    avatar?.addEventListener("mouseover", showProfileDebounce);
+                                tryObserve(userInfo.shadowRoot);
+                                const userNameA = userInfo.shadowRoot?.querySelector("#user-name > a");
+                                userNameA?.addEventListener("mouseover", showProfileDebounce);
+                            }
 
-                                    const userNameA = userInfo.shadowRoot?.querySelector("#user-name > a");
-                                    userNameA?.addEventListener("mouseover", showProfileDebounce);
-                                }
-
-                                const richText = reply.shadowRoot.querySelector("bili-rich-text");
-                                if (richText) {
+                            const richText = reply.shadowRoot.querySelector("bili-rich-text");
+                            if (richText) {
+                                setTimeout(() => {
                                     const userNameAts = richText.shadowRoot.querySelectorAll("a[data-user-profile-id]");
                                     for (const userNameAt of userNameAts) {
                                         userNameAt.addEventListener("mouseover", showProfileDebounce);
                                     }
-                                }
+                                }, 0);
                             }
-                        }, 0);
+                        }
                     }
 
                 }

--- a/scripts/load.js
+++ b/scripts/load.js
@@ -100,6 +100,7 @@ window.addEventListener("load", function() {
 
                         const richText = mainComment.shadowRoot.querySelector("bili-rich-text");
                         if (richText) {
+                            tryObserve(richText.shadowRoot);
                             const userNameAts = richText.shadowRoot.querySelectorAll("a[data-user-profile-id]");
                             for (const userNameAt of userNameAts) {
                                 userNameAt.addEventListener("mouseover", showProfileDebounce);
@@ -117,19 +118,17 @@ window.addEventListener("load", function() {
                                 const avatar = userInfo.querySelector("#user-avatar");
                                 avatar?.addEventListener("mouseover", showProfileDebounce);
 
-                                tryObserve(userInfo.shadowRoot);
                                 const userNameA = userInfo.shadowRoot?.querySelector("#user-name > a");
                                 userNameA?.addEventListener("mouseover", showProfileDebounce);
                             }
 
                             const richText = reply.shadowRoot.querySelector("bili-rich-text");
                             if (richText) {
-                                setTimeout(() => {
-                                    const userNameAts = richText.shadowRoot.querySelectorAll("a[data-user-profile-id]");
-                                    for (const userNameAt of userNameAts) {
-                                        userNameAt.addEventListener("mouseover", showProfileDebounce);
-                                    }
-                                }, 0);
+                                tryObserve(richText.shadowRoot);
+                                const userNameAts = richText.shadowRoot.querySelectorAll("a[data-user-profile-id]");
+                                for (const userNameAt of userNameAts) {
+                                    userNameAt.addEventListener("mouseover", showProfileDebounce);
+                                }
                             }
                         }
                     }

--- a/scripts/load.js
+++ b/scripts/load.js
@@ -124,10 +124,12 @@ window.addEventListener("load", function() {
 
                             const richText = reply.shadowRoot.querySelector("bili-rich-text");
                             if (richText) {
-                                const userNameAts = richText.shadowRoot.querySelectorAll("a[data-user-profile-id]");
-                                for (const userNameAt of userNameAts) {
-                                    userNameAt.addEventListener("mouseover", showProfileDebounce);
-                                }
+                                setTimeout(() => {
+                                    const userNameAts = richText.shadowRoot.querySelectorAll("a[data-user-profile-id]");
+                                    for (const userNameAt of userNameAts) {
+                                        userNameAt.addEventListener("mouseover", showProfileDebounce);
+                                    }
+                                }, 0);
                             }
                         }
                     }

--- a/scripts/load.js
+++ b/scripts/load.js
@@ -100,6 +100,7 @@ window.addEventListener("load", function() {
 
                         const richText = mainComment.shadowRoot.querySelector("bili-rich-text");
                         if (richText) {
+                            tryObserve(richText.shadowRoot);
                             const userNameAts = richText.shadowRoot.querySelectorAll("a");
                             for (const userNameAt of userNameAts) {
                                 userNameAt.addEventListener("mouseover", showProfileDebounce);
@@ -124,6 +125,7 @@ window.addEventListener("load", function() {
 
                             const richText = reply.shadowRoot.querySelector("bili-rich-text");
                             if (richText) {
+                                tryObserve(richText.shadowRoot);
                                 const userNameAts = richText.shadowRoot.querySelectorAll("a");
                                 for (const userNameAt of userNameAts) {
                                     userNameAt.addEventListener("mouseover", showProfileDebounce);

--- a/scripts/load.js
+++ b/scripts/load.js
@@ -100,7 +100,6 @@ window.addEventListener("load", function() {
 
                         const richText = mainComment.shadowRoot.querySelector("bili-rich-text");
                         if (richText) {
-                            tryObserve(richText.shadowRoot);
                             const userNameAts = richText.shadowRoot.querySelectorAll("a");
                             for (const userNameAt of userNameAts) {
                                 userNameAt.addEventListener("mouseover", showProfileDebounce);
@@ -125,7 +124,6 @@ window.addEventListener("load", function() {
 
                             const richText = reply.shadowRoot.querySelector("bili-rich-text");
                             if (richText) {
-                                tryObserve(richText.shadowRoot);
                                 const userNameAts = richText.shadowRoot.querySelectorAll("a");
                                 for (const userNameAt of userNameAts) {
                                     userNameAt.addEventListener("mouseover", showProfileDebounce);

--- a/scripts/load.js
+++ b/scripts/load.js
@@ -118,6 +118,7 @@ window.addEventListener("load", function() {
                                 const avatar = userInfo.querySelector("#user-avatar");
                                 avatar?.addEventListener("mouseover", showProfileDebounce);
 
+                                tryObserve(userInfo.shadowRoot);
                                 const userNameA = userInfo.shadowRoot?.querySelector("#user-name > a");
                                 userNameA?.addEventListener("mouseover", showProfileDebounce);
                             }


### PR DESCRIPTION
给新评论区里的 `@用户` 增加用户卡片显示。
![image](https://github.com/user-attachments/assets/cbf0f7fe-c36b-42ae-b3d0-e865f378a402)

由于该元素有 data-user-profile-id 属性，所以不需要显式标注。
![image](https://github.com/user-attachments/assets/9d1fd7aa-ce83-4233-83a4-8174b4d66212)
