### PR TITLE
Let computedStyle as constants

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -632,10 +632,10 @@ UserProfileCard.prototype.setupTriggers = function() {
     });
 }
 
-UserProfileCard.prototype.drawWordCloud = function(canvas) {
-    canvas.style.height = `${canvas.offsetWidth / 2}px`;
-    canvas.width = canvas.offsetWidth * window.devicePixelRatio;
-    canvas.height = canvas.offsetHeight * window.devicePixelRatio;
+UserProfileCard.prototype.drawWordCloud = function (canvas) {
+    canvas.style.height = "187.5px";
+    canvas.width = 375 * window.devicePixelRatio;
+    canvas.height = 187.5 * window.devicePixelRatio;
 
     canvas.parentNode.classList.add("biliscope-canvas-show");
 

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -633,9 +633,11 @@ UserProfileCard.prototype.setupTriggers = function() {
 }
 
 UserProfileCard.prototype.drawWordCloud = function (canvas) {
-    canvas.style.height = "187.5px";
-    canvas.width = 375 * window.devicePixelRatio;
-    canvas.height = 187.5 * window.devicePixelRatio;
+    let cardWidth = window.getComputedStyle(document.getElementById("biliscope-id-card")).width;
+    cardWidth = parseInt(cardWidth.replace("px", ""));
+    canvas.style.height = `${cardWidth / 2}px`;
+    canvas.width = cardWidth * window.devicePixelRatio;
+    canvas.height = cardWidth / 2 * window.devicePixelRatio;
 
     canvas.parentNode.classList.add("biliscope-canvas-show");
 

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -633,8 +633,8 @@ UserProfileCard.prototype.setupTriggers = function() {
 }
 
 UserProfileCard.prototype.drawWordCloud = function(canvas) {
-    let cardWidth = window.getComputedStyle(document.getElementById("biliscope-id-card")).width;
-    cardWidth = parseInt(cardWidth.replace("px", ""));
+    const idCard = document.getElementById("biliscope-id-card");
+    const cardWidth = parseInt(window.getComputedStyle(idCard).width.replace("px", ""));
 
     canvas.style.height = `${cardWidth / 2}px`;
     canvas.width = cardWidth * window.devicePixelRatio;

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -632,7 +632,7 @@ UserProfileCard.prototype.setupTriggers = function() {
     });
 }
 
-UserProfileCard.prototype.drawWordCloud = function (canvas) {
+UserProfileCard.prototype.drawWordCloud = function(canvas) {
     let cardWidth = window.getComputedStyle(document.getElementById("biliscope-id-card")).width;
     cardWidth = parseInt(cardWidth.replace("px", ""));
     canvas.style.height = `${cardWidth / 2}px`;

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -635,6 +635,7 @@ UserProfileCard.prototype.setupTriggers = function() {
 UserProfileCard.prototype.drawWordCloud = function(canvas) {
     let cardWidth = window.getComputedStyle(document.getElementById("biliscope-id-card")).width;
     cardWidth = parseInt(cardWidth.replace("px", ""));
+
     canvas.style.height = `${cardWidth / 2}px`;
     canvas.width = cardWidth * window.devicePixelRatio;
     canvas.height = cardWidth / 2 * window.devicePixelRatio;


### PR DESCRIPTION
## 问题原因
f073113c2a626de3f158a290b033e4248722206a，改了 `this.valid = false;` 后，用户卡片在 `info` 请求之后才确定显不显示。
如果词云在卡片显示前绘制，那图中三个要计算的值都为 0。

![image](https://github.com/user-attachments/assets/c8f95a74-8f06-4755-9c2b-cc6d9c7cfefd)

## 解决方式

将这些要计算的值设置为常量，因为父组件的长宽是固定的。

## 复现

https://space.bilibili.com/31485103

---

fix #260