### PR TITLE
Fix the color of the rollback button in dark mode

### DIFF
--- a/scripts/rollbackfeedcard.js
+++ b/scripts/rollbackfeedcard.js
@@ -10,12 +10,12 @@ FeedcardManager.prototype.addButton = function (parentNode) {
     buttonWrapper.innerHTML = `
         <button id="biliscope-feedcard-backward" class="primary-btn roll-btn" style="margin-top: 15px; margin-bottom: 10px; display: none">
             <svg width="16" height="16" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 3px 0; scale: 0.85; transform: translateY(-1px); rotate: -90deg;">
-                <path fill-rule="evenodd" clip-rule="evenodd" d="M22.2692 6.98965C23.0395 5.65908 24.9605 5.65908 25.7309 6.98965L44.262 38.9979C45.0339 40.3313 44.0718 42 42.5311 42H5.4689C3.92823 42 2.96611 40.3313 3.73804 38.9979L22.2692 6.98965Z" fill="none" stroke="#000" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+                <path fill-rule="evenodd" clip-rule="evenodd" d="M22.2692 6.98965C23.0395 5.65908 24.9605 5.65908 25.7309 6.98965L44.262 38.9979C45.0339 40.3313 44.0718 42 42.5311 42H5.4689C3.92823 42 2.96611 40.3313 3.73804 38.9979L22.2692 6.98965Z" fill="none" stroke="currentColor" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
         </button>
         <button id="biliscope-feedcard-forward" class="primary-btn roll-btn" style="display: none;">
             <svg width="16" height="16" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 3px 0; scale: 0.85; transform: translateY(-1px); rotate: 90deg;">
-                <path fill-rule="evenodd" clip-rule="evenodd" d="M22.2692 6.98965C23.0395 5.65908 24.9605 5.65908 25.7309 6.98965L44.262 38.9979C45.0339 40.3313 44.0718 42 42.5311 42H5.4689C3.92823 42 2.96611 40.3313 3.73804 38.9979L22.2692 6.98965Z" fill="none" stroke="#000" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+                <path fill-rule="evenodd" clip-rule="evenodd" d="M22.2692 6.98965C23.0395 5.65908 24.9605 5.65908 25.7309 6.98965L44.262 38.9979C45.0339 40.3313 44.0718 42 42.5311 42H5.4689C3.92823 42 2.96611 40.3313 3.73804 38.9979L22.2692 6.98965Z" fill="none" stroke="currentColor" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
         </button>
         <style>


### PR DESCRIPTION
B站增加了深色模式，首页换一换前进后退按钮图标颜色要适配一下。

`currentColor` 来自上面换一换中图标的颜色。

前：

![image](https://github.com/user-attachments/assets/e2ab3894-d63f-46cb-aa6c-d302018abda8)

后：

![image](https://github.com/user-attachments/assets/748b2c47-8525-42d0-b5be-7e9a52e1891c)
