### PR TITLE
Fix feedcard mouse event (#296)

### DIFF
--- a/scripts/rollbackfeedcard.js
+++ b/scripts/rollbackfeedcard.js
@@ -3,6 +3,7 @@ function FeedcardManager() {
     this.forwardStack = [];
     this.backwardButton = null;
     this.forwardButton = null;
+    this.isCustomMouseListenerActive = false;
 }
 
 FeedcardManager.prototype.addButton = function (parentNode) {
@@ -42,6 +43,24 @@ FeedcardManager.prototype.addButton = function (parentNode) {
     this.forwardButton.addEventListener('click', () => {
         this.forward();
     });
+
+    const feedcardContainer = document.querySelector('.container');
+    if (feedcardContainer) {
+        feedcardContainer.addEventListener('mouseenter', (e) => {
+            if (!this.isCustomMouseListenerActive ||
+                !e.target.classList.contains('bili-video-card__image') ||
+                !e.target.closest('.feed-card'))
+                return;
+            e.target.classList.add('bili-video-card__image--hover');
+        }, { capture: true });
+        feedcardContainer.addEventListener('mouseleave', (e) => {
+            if (!this.isCustomMouseListenerActive ||
+                !e.target.classList.contains('bili-video-card__image') ||
+                !e.target.closest('.feed-card'))
+                return;
+            e.target.classList.remove('bili-video-card__image--hover');
+        }, { capture: true });
+    }
 }
 
 FeedcardManager.prototype.refreshButtonState = function () {
@@ -53,8 +72,10 @@ FeedcardManager.prototype.refreshButtonState = function () {
     }
     if (this.forwardStack.length > 0) {
         this.forwardButton.style.display = 'block';
+        this.isCustomMouseListenerActive = true;
     } else {
         this.forwardButton.style.display = 'none';
+        this.isCustomMouseListenerActive = false;
     }
 }
 


### PR DESCRIPTION
换一换的视频卡片在还原回去的时候会丢失部分 `mouseenter` 和 `mouseleave` 事件，导致视频信息在鼠标移入不会自动隐藏

此 PR 在父级添加 `Listener` ，使用事件委托处理受影响的卡片的视频信息显示/隐藏

resolve #296